### PR TITLE
add Infotext

### DIFF
--- a/scripts/script.py
+++ b/scripts/script.py
@@ -29,6 +29,8 @@ except OSError:
     except FileExistsError:pass
 
 class script(scripts.Script):
+        infotext_fields = []
+
         def title(self):
             return EXTENSION_NAME
 
@@ -41,6 +43,8 @@ class script(scripts.Script):
                 if not os.path.exists(INPAINT_PANTS):
                     checkbox.input(fn=download_model,inputs=checkbox,outputs=checkbox)
 
+            self.infotext_fields.append((checkbox, lambda d: 'Convert inpaint' in d))
+
             return [checkbox]
 
         def setup(self,p,enabled,*args,**kwargs):
@@ -51,6 +55,11 @@ class script(scripts.Script):
                         if model:
                             p.sd_model = model
                             #p.cached_c[0] = None
+                            # if model is converted successfully, extra_generation_params
+                            p.extra_generation_params['Convert inpaint'] = True
+                    else:
+                        # if model is already converted set extra_generation_params
+                        p.extra_generation_params['Convert inpaint'] = True
                 elif shared.sd_model.used_config == sd_models_config.config_inpainting:
                     convert(reverse=True)
             return p

--- a/scripts/script.py
+++ b/scripts/script.py
@@ -62,7 +62,6 @@ class script(scripts.Script):
                         p.extra_generation_params['Convert inpaint'] = True
                 elif shared.sd_model.used_config == sd_models_config.config_inpainting:
                     convert(reverse=True)
-            return p
 
 
 def convert(reverse=False):


### PR DESCRIPTION
add infotext `Convert inpaint` True when model is conveted into inpaint model
`p.extra_generation_params['Convert inpaint'] = True`

this registered the infotext to be read by the UI
`self.infotext_fields.append((checkbox, lambda d: 'Convert inpaint' in d))`

---

if you don't like `Convert inpaint` you can rename it to something else
but if you're going to do this it's better to do this before it gets listed on index
